### PR TITLE
Update for Jellyfin 10.5; fix UserId

### DIFF
--- a/MediaBrowser.Plugins.SmtpNotifications/Api/ServerApiEntryPoints.cs
+++ b/MediaBrowser.Plugins.SmtpNotifications/Api/ServerApiEntryPoints.cs
@@ -12,7 +12,7 @@ namespace MediaBrowser.Plugins.SmtpNotifications.Api
     public class TestNotification : IReturnVoid
     {
         [ApiMember(Name = "UserID", Description = "User Id", IsRequired = true, DataType = "string", ParameterType = "path", Verb = "POST")]
-        public string UserID { get; set; }
+        public string UserId { get; set; }
     }
 
     public class ServerApiEndpoints : IService
@@ -33,8 +33,8 @@ namespace MediaBrowser.Plugins.SmtpNotifications.Api
                 Date = DateTime.UtcNow,
                 Description = "This is a test notification from Jellyfin Server",
                 Level = Model.Notifications.NotificationLevel.Normal,
-                Name = "Jellyfin: Test Notification",
-                User = _userManager.GetUserById(request.UserID)
+                Name = "Test Notification",
+                User = _userManager.GetUserById(Guid.Parse(request.UserId))
             }, CancellationToken.None);
         }
     }

--- a/MediaBrowser.Plugins.SmtpNotifications/MediaBrowser.Plugins.SmtpNotifications.csproj
+++ b/MediaBrowser.Plugins.SmtpNotifications/MediaBrowser.Plugins.SmtpNotifications.csproj
@@ -1,21 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-    <AssemblyVersion>5.0.0</AssemblyVersion>
-    <FileVersion>5.0.0</FileVersion>
+    <TargetFramework>netstandard2.1</TargetFramework>
+    <AssemblyVersion>6.0.0</AssemblyVersion>
+    <FileVersion>6.0.0</FileVersion>
   </PropertyGroup>
-
   <ItemGroup>
-    <None Remove="Configuration\config.html" />
+    <None Remove="Configuration\config.html"/>
   </ItemGroup>
-
   <ItemGroup>
-    <EmbeddedResource Include="Configuration\config.html" />
+    <EmbeddedResource Include="Configuration\config.html"/>
   </ItemGroup>
-
   <ItemGroup>
-    <PackageReference Include="Jellyfin.Controller" Version="10.*" />
+    <PackageReference Include="Jellyfin.Controller" Version="10.*"/>
   </ItemGroup>
-
 </Project>

--- a/MediaBrowser.Plugins.SmtpNotifications/Plugin.cs
+++ b/MediaBrowser.Plugins.SmtpNotifications/Plugin.cs
@@ -13,7 +13,7 @@ namespace MediaBrowser.Plugins.SmtpNotifications
     /// </summary>
     public class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
     {
-        private Guid _id = new Guid("cfa0f7f4-4155-4d71-849b-d6598dc4c5bb");
+        private readonly Guid _id = new Guid("cfa0f7f4-4155-4d71-849b-d6598dc4c5bb");
 
         public Plugin(IApplicationPaths applicationPaths, IXmlSerializer xmlSerializer)
             : base(applicationPaths, xmlSerializer)

--- a/build.yaml
+++ b/build.yaml
@@ -1,8 +1,8 @@
 ---
 name: "jellyfin-plugin-emailnotifications"
 guid: "cfa0f7f4-4155-4d71-849b-d6598dc4c5bb"
-version: "5" # Please increment with each pull request
-jellyfin_version: "10.3.0" # The earliest binary-compatible version
+version: "6" # Please increment with each pull request
+jellyfin_version: "10.5.0" # The earliest binary-compatible version
 owner: "jellyfin"
 nicename: "Email"
 description: "Send SMTP email notifications"
@@ -12,4 +12,4 @@ artifacts:
   - "MediaBrowser.Plugins.SmtpNotifications.dll"
 build_type: "dotnet"
 dotnet_configuration: "Release"
-dotnet_framework: "netstandard2.0"
+dotnet_framework: "netstandard2.1"


### PR DESCRIPTION
Parses the UserId to stop the throw causing an error.

I also assume due to moving to netstandard2.1 it's not compatible with older Jellyfin's, but I'm not sure.