### PR TITLE
chore: plugin images

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -16,7 +16,7 @@ jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
-    if: github.repository == 'jellyfin/jellyfin-plugin-emailnotifications'
+    if: github.repository == 'jellyfin/jellyfin-plugin-email'
 
     strategy:
       fail-fast: false

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -16,6 +16,7 @@ jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
+    if: github.repository == 'jellyfin/jellyfin-plugin-emailnotifications'
 
     strategy:
       fail-fast: false

--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   publish_release_draft:
     runs-on: ubuntu-latest
-    if: github.repository == 'jellyfin/jellyfin-plugin-emailnotifications'
+    if: github.repository == 'jellyfin/jellyfin-plugin-email'
     
     steps:
       - name: Get version from GITHUB_REF

--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   publish_release_draft:
     runs-on: ubuntu-latest
+    if: github.repository == 'jellyfin/jellyfin-plugin-emailnotifications'
+    
     steps:
       - name: Get version from GITHUB_REF
         id: get-version

--- a/.github/workflows/update-release-draft.yml
+++ b/.github/workflows/update-release-draft.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   update_release_draft:
     runs-on: ubuntu-latest
-    if: github.repository == 'jellyfin/jellyfin-plugin-emailnotifications'
+    if: github.repository == 'jellyfin/jellyfin-plugin-email'
     
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "master"

--- a/.github/workflows/update-release-draft.yml
+++ b/.github/workflows/update-release-draft.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   update_release_draft:
     runs-on: ubuntu-latest
+    if: github.repository == 'jellyfin/jellyfin-plugin-emailnotifications'
+    
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "master"
       - uses: release-drafter/release-drafter@v5.15.0

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 <h3 align="center">Part of the <a href="https://jellyfin.media">Jellyfin Project</a></h3>
 
 <p align="center">
-<img alt="Logo Banner" src="https://raw.githubusercontent.com/jellyfin/jellyfin-ux/master/branding/SVG/banner-logo-solid.svg?sanitize=true"/>
+<img alt="Plugin Banner" src="https://raw.githubusercontent.com/jellyfin/jellyfin-ux/master/plugins/SVG/jellyfin-plugin-emailnotifications.svg?sanitize=true"/>
 <br/>
 <br/>
 <a href="https://github.com/jellyfin/jellyfin-plugin-emailnotifications/actions?query=workflow%3A%22Test+Build+Plugin%22">
@@ -17,16 +17,29 @@
 </p>
 
 ## About
-Jellyfin Email plugin is a notification plugin to send Jellyfin notifications via mail
+This plugin allows you to send Jellyfin notifications via email (SMTP).
 
-## Build Process
+## Build
 
-1. Clone or download this repository
+1. To build this plugin you will need [.Net 5.x](https://dotnet.microsoft.com/download/dotnet/5.0).
 
-2. Ensure you have .NET Core 5.0 SDK setup and installed
+2. Build plugin with following command
+  ```
+  dotnet publish --configuration Release --output bin
+  ```
 
-3. Build plugin with following command.
+3. Place the dll-file in the `plugins/emailnotifications` folder (you might need to create the folders) of your JF install
 
-```sh
-dotnet publish --configuration Release --output bin
-```
+## Releasing
+
+To release the plugin we recommend [JPRM](https://github.com/oddstr13/jellyfin-plugin-repository-manager) that will build and package the plugin.
+For additional context and for how to add the packaged plugin zip to a plugin manifest see the [JPRM documentation](https://github.com/oddstr13/jellyfin-plugin-repository-manager) for more info.
+
+## Contributing
+
+We welcome all contributions and pull requests! If you have a larger feature in mind please open an issue so we can discuss the implementation before you start.
+In general refer to our [contributing guidelines](https://github.com/jellyfin/.github/blob/master/CONTRIBUTING.md) for further information.
+
+## Licence
+
+This plugins code and packages are distributed under the MIT License. See [LICENSE](./LICENSE) for more information.

--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@
 ## About
 This plugin allows you to send Jellyfin notifications via email (SMTP).
 
+## Installation
+
+[See the official documentation for install instructions](https://jellyfin.org/docs/general/server/plugins/index.html#installing).
+
 ## Build
 
 1. To build this plugin you will need [.Net 5.x](https://dotnet.microsoft.com/download/dotnet/5.0).

--- a/build.yaml
+++ b/build.yaml
@@ -1,6 +1,7 @@
 ---
 name: "Email"
 guid: "cfa0f7f4-4155-4d71-849b-d6598dc4c5bb"
+imageUrl: "https://repo.jellyfin.org/releases/plugin/images/jellyfin-plugin-emailnotifications.png"
 version: "9.0.0.0"
 targetAbi: "10.7.0.0"
 framework: "net5.0"
@@ -9,9 +10,9 @@ overview: "Send SMTP email notifications"
 description: "Send SMTP email notifications"
 category: "Notifications"
 artifacts:
-- "MediaBrowser.Plugins.SmtpNotifications.dll"
-- "BouncyCastle.Crypto.dll"
-- "MailKit.dll"
-- "MimeKit.dll"
-changelog: >
+  - "MediaBrowser.Plugins.SmtpNotifications.dll"
+  - "BouncyCastle.Crypto.dll"
+  - "MailKit.dll"
+  - "MimeKit.dll"
+changelog: |
   changelog


### PR DESCRIPTION
* applies some smaller improvements to workflows
* updates readme with plugin-image
* adds plugin `imageUrl` to build.yaml

Merge Checklist:

* [x] either manually or via CI add plugin-images to [repo.jellyfin.org](https://repo.jellyfin.org/releases/plugin/)
* [x] ensure the plugin png is present within the plugin directory with the correct name on `repo.jellyfin.org`